### PR TITLE
fix(cloud-consumer-order80): cloud-consumer-order80 模块的 pom.xml依赖错误

### DIFF
--- a/cloud-consumer-order80/pom.xml
+++ b/cloud-consumer-order80/pom.xml
@@ -31,7 +31,7 @@
         <!--eureka client-->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
         <!--热部署-->
         <dependency>


### PR DESCRIPTION
cloud-consumer-order80 模块的pom.xml中eureka-client的依赖应该是spring-cloud-starter-netflix-eureka-client
而不是spring-cloud-starter-netflix-eureka-server 容易引起混淆